### PR TITLE
Handle files with UTF8 Byte Order Mark properly (fixes #4)

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -214,7 +214,7 @@ fn byte_strings() {
 
 #[test]
 fn utf8_bom_quotes() {
-    let mut d = Csv::from_reader(&b"\xef\xbb\xbf\"abc\",\"xyz\"\n"[..]);
+    let mut d = Csv::from_reader(&b"\xef\xbb\xbf\"abc\",\"xyz\""[..]);
     let r = d.next().unwrap().unwrap();
     let c = r.bytes_columns().collect::<Vec<_>>();
     assert_eq!(c, vec![b"abc", b"xyz"]);

--- a/src/test.rs
+++ b/src/test.rs
@@ -213,6 +213,15 @@ fn byte_strings() {
 }
 
 #[test]
+fn utf8_bom_quotes() {
+    let mut d = Csv::from_reader(&b"\xef\xbb\xbf\"abc\",\"xyz\"\n"[..]);
+    let r = d.next().unwrap().unwrap();
+    let c = r.bytes_columns().collect::<Vec<_>>();
+    assert_eq!(c, vec![b"abc", b"xyz"]);
+}
+
+
+#[test]
 fn byte_strings_invalid_utf8() {
     let mut d = Csv::from_reader(&b"a\xffbc,xyz"[..]);
     let r = d.next().unwrap().unwrap();


### PR DESCRIPTION
See #4

The patch fixes the bug but somehow there's still a weird coner case that it fails to parse `\xef\xbb\xbf\"abc\",\"xyz\"` (without the trailing newline), returning a UnexpextedQuote error. I don't really get why this happens only when there was a BOM present (parses successfully without the BOM).
